### PR TITLE
Validate `viewTransitionName` & Performance Improvements

### DIFF
--- a/ngx-easy-view-transitions/src/lib/keyframes.service.ts
+++ b/ngx-easy-view-transitions/src/lib/keyframes.service.ts
@@ -12,9 +12,9 @@ export class KeyframesService {
   setKeyframes(keyframes: Keyframe[]) {
     const keyframesAsString = JSON.stringify(keyframes);
     const hashedKeyframes = hashCode(keyframesAsString);
-    const keyframesName = `_${hashedKeyframes}`;
+    const keyframesName = `keyframes-${hashedKeyframes}`;
 
-    const elementId = `keyframes-${keyframesName}`;
+    const elementId = keyframesName;
 
     const styleElement = this._document.getElementById(elementId) || this._document.createElement('style');
 

--- a/ngx-easy-view-transitions/src/lib/keyframes.service.ts
+++ b/ngx-easy-view-transitions/src/lib/keyframes.service.ts
@@ -9,19 +9,25 @@ export class KeyframesService {
   private readonly _renderer = this._rendererFactory.createRenderer(null, null);
   private readonly _document = inject(DOCUMENT);
 
+  private readonly _insertedKeyframes = new Set<string>();
+
   setKeyframes(keyframes: Keyframe[]) {
     const keyframesAsString = JSON.stringify(keyframes);
     const hashedKeyframes = hashCode(keyframesAsString);
     const keyframesName = `keyframes-${hashedKeyframes}`;
 
-    const elementId = keyframesName;
+    if (this._insertedKeyframes.has(keyframesName)) return keyframesName;
 
-    const styleElement = this._document.getElementById(elementId) || this._document.createElement('style');
+    const styleElement = this._renderer.createElement('style') as HTMLStyleElement;
 
-    styleElement.innerHTML = this.generateCssKeyframeRule(keyframesName, keyframes);
-    styleElement.id = elementId;
+    this._renderer.setAttribute(styleElement, 'id', keyframesName);
 
-    if (!this._document.getElementById(elementId)) this._renderer.appendChild(this._document.head, styleElement);
+    const cssKeyframeRule = this.generateCssKeyframeRule(keyframesName, keyframes);
+    this._renderer.setProperty(styleElement, 'innerHTML', cssKeyframeRule);
+
+    this._renderer.appendChild(this._document.head, styleElement);
+
+    this._insertedKeyframes.add(keyframesName);
 
     return keyframesName;
   }

--- a/ngx-easy-view-transitions/src/lib/utils.ts
+++ b/ngx-easy-view-transitions/src/lib/utils.ts
@@ -8,3 +8,22 @@ export function hashCode(str: string): number {
   }
   return hash;
 }
+
+/**@internal*/
+export function isValidCustomIdentValue(value: string): boolean {
+  const regex =
+    /^(?:[A-Za-z_]|-(?!\d)|\\[0-9A-Fa-f]{1,6}|\\.)[A-Za-z0-9_-]*(?:\\[0-9A-Fa-f]{1,6}|\\.)*[A-Za-z0-9_-]*$/u;
+
+  return regex.test(value);
+}
+
+/**@internal*/
+export function isValidViewTransitionName(value: string): boolean {
+  return (
+    isValidCustomIdentValue(value) &&
+    value !== 'unset' &&
+    value !== 'initial' &&
+    value !== 'inherit' &&
+    value !== 'none'
+  );
+}


### PR DESCRIPTION
This closes #2 which is a follow up of the problem descibed in #1 where invalid view-transition-names lead to unexpected behavior.

This PR validates the provided `view-transition-name` and shows a warning if the name is potentially invalid.

This PR also includes performance improvements by looking up injected keyframes in an internal `Set` instead of querying the DOM.

Also more code uses `Renderer2` instead of `Document` for manipulating DOM.