### PR TITLE
feat: add hashing to transitionName

### DIFF
--- a/README.md
+++ b/README.md
@@ -163,11 +163,21 @@ But you can also provide your own in and out animations by adding the `provideDe
 
 In the following example, the default animation gets disabled:
 
+<!-- prettier-ignore-start -->
 ```typescript
-bootstrapApplication(AppComponent, {
-  providers: [provideRouter(appRoutes, withViewTransitions()), provideDefaultViewTransition({ keyframes: DefaultTransitions.none, duration: 0 }, { keyframes: DefaultTransitions.none, duration: 0 })]
-});
+bootstrapApplication(AppComponent,
+  {
+    providers: [
+      provideRouter(appRoutes, withViewTransitions()),
+      provideDefaultViewTransition(
+        {keyframes: DefaultTransitions.none, duration: 0},
+        {keyframes: DefaultTransitions.none, duration: 0}
+      )
+    ]
+  }
+);
 ```
+<!-- prettier-ignore-end -->
 
 ### Troubleshooting
 

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ npm install ngx-easy-view-transitions
 
 Required Angular version: `>=19.0.0`
 
-You have to enable Angulars built-in view transitions in the Router using the [`withViewTransitions()`](https://angular.io/api/router/withViewTransitions#usage-notes) function.
+You have to enable Angular's built-in view transitions in the Router using the [`withViewTransitions()`](https://angular.io/api/router/withViewTransitions#usage-notes) function.
 
 ```typescript
 bootstrapApplication(AppComponent, {
@@ -32,10 +32,10 @@ bootstrapApplication(AppComponent, {
 
 ### Morph elements
 
-To morph an element during navigation from the old to the new state use the `transitionName` directive and provide the same name on both pages.
+To morph an element during navigation from the old to the new state, use the `transitionName` directive and provide the same name on both pages.
 
 ```typescript
-import {TransitionNameDirective} from 'ngx-easy-view-transitions';
+import { TransitionNameDirective } from 'ngx-easy-view-transitions';
 ```
 
 `users.component.html`
@@ -51,6 +51,13 @@ import {TransitionNameDirective} from 'ngx-easy-view-transitions';
 ```
 
 Note that each `transitionName` must be unique for a page.
+
+Transition names must be valid [`<custom-ident>`](https://developer.mozilla.org/en-US/docs/Web/CSS/custom-ident).
+This library helps with this, by hashing the name to automatically comply.
+
+For debugging purposes, you can show the original provided value as `data-original-view-transition-name` attribute by setting `showOriginalNameAttr` to `true`.
+
+To opt out of hashing, set `preserveName` to `true`.
 
 ### Customize animations
 
@@ -74,8 +81,8 @@ You can simply use a CSS [`@keyframes`](https://developer.mozilla.org/en-US/docs
 ```
 
 ```typescript
-inAnimation = {keyframeName: 'fadeIn', duration: 600};
-outAnimation = {keyframeName: 'fadeIn', duration: 600, reverse: true};
+inAnimation = { keyframeName: 'fadeIn', duration: 600 };
+outAnimation = { keyframeName: 'fadeIn', duration: 600, reverse: true };
 ```
 
 ```angular2html
@@ -84,7 +91,7 @@ outAnimation = {keyframeName: 'fadeIn', duration: 600, reverse: true};
 
 #### Using Keyframe array
 
-When you want to use typed objects instead of CSS you can provide a [`Keyframe`](https://developer.mozilla.org/en-US/docs/Web/API/Web_Animations_API/Keyframe_Formats) array:
+When you want to use typed objects instead of CSS, you can provide a [`Keyframe`](https://developer.mozilla.org/en-US/docs/Web/API/Web_Animations_API/Keyframe_Formats) array:
 
 ```typescript
 const fadeIn: Keyframe[] = [
@@ -100,8 +107,8 @@ const fadeIn: Keyframe[] = [
 ```
 
 ```typescript
-inAnimation = {keyframes: fadeIn, duration: 600};
-outAnimation = {keyframes: fadeIn, duration: 600, reverse: true};
+inAnimation = { keyframes: fadeIn, duration: 600 };
+outAnimation = { keyframes: fadeIn, duration: 600, reverse: true };
 ```
 
 ```angular2html
@@ -127,22 +134,22 @@ animation = {
 
 ### Built-In animations
 
-To start faster there are some built-in animations available under `DefaultTransitions.*`.
+To start faster, there are some built-in animations available under `DefaultTransitions.*`.
 
 ```typescript
-import {DefaultTransitions} from 'ngx-easy-view-transitions';
+import { DefaultTransitions } from 'ngx-easy-view-transitions';
 
-inAnimation = {keyframes: DefaultTransitions.fadeInUp, duration: 600};
+inAnimation = { keyframes: DefaultTransitions.fadeInUp, duration: 600 };
 ```
 
-You can see them in the [demo](https://derstimmler.github.io/ngx-easy-view-transitions/animations) and [here](https://github.com/DerStimmler/ngx-easy-view-transitions/blob/main/ngx-easy-view-transitions/src/lib/default-transitions.ts).
+You can check them out in the [demo](https://derstimmler.github.io/ngx-easy-view-transitions/animations) and [here](https://github.com/DerStimmler/ngx-easy-view-transitions/blob/main/ngx-easy-view-transitions/src/lib/default-transitions.ts).
 
 ### Exclude element from view transitions
 
 When you want to exclude an element from view transitions, you can add the `noTransition` directive.
 
 ```typescript
-import {NoTransitionDirective} from 'ngx-easy-view-transitions';
+import { NoTransitionDirective } from 'ngx-easy-view-transitions';
 ```
 
 ```angular2html
@@ -157,17 +164,9 @@ But you can also provide your own in and out animations by adding the `provideDe
 In the following example, the default animation gets disabled:
 
 ```typescript
-bootstrapApplication(AppComponent,
-  {
-    providers: [
-      provideRouter(appRoutes, withViewTransitions()),
-      provideDefaultViewTransition(
-        {keyframes: DefaultTransitions.none, duration: 0},
-        {keyframes: DefaultTransitions.none, duration: 0}
-      )
-    ]
-  }
-);
+bootstrapApplication(AppComponent, {
+  providers: [provideRouter(appRoutes, withViewTransitions()), provideDefaultViewTransition({ keyframes: DefaultTransitions.none, duration: 0 }, { keyframes: DefaultTransitions.none, duration: 0 })]
+});
 ```
 
 ### Troubleshooting

--- a/ngx-easy-view-transitions/src/lib/keyframes.service.ts
+++ b/ngx-easy-view-transitions/src/lib/keyframes.service.ts
@@ -1,5 +1,5 @@
 import { inject, Injectable, RendererFactory2 } from '@angular/core';
-import { hashCode } from './utils';
+import { fnv1aHash } from './utils';
 import { DOCUMENT } from '@angular/common';
 
 /**@internal*/
@@ -13,7 +13,7 @@ export class KeyframesService {
 
   setKeyframes(keyframes: Keyframe[]) {
     const keyframesAsString = JSON.stringify(keyframes);
-    const hashedKeyframes = hashCode(keyframesAsString);
+    const hashedKeyframes = fnv1aHash(keyframesAsString);
     const keyframesName = `keyframes-${hashedKeyframes}`;
 
     if (this._insertedKeyframes.has(keyframesName)) return keyframesName;

--- a/ngx-easy-view-transitions/src/lib/transition-name.directive.ts
+++ b/ngx-easy-view-transitions/src/lib/transition-name.directive.ts
@@ -1,9 +1,9 @@
-import { Directive, effect, ElementRef, inject, input, Renderer2 } from '@angular/core';
+import { computed, Directive, effect, ElementRef, inject, input, Renderer2, untracked } from '@angular/core';
 import { KeyframesTransition } from './keyframes-transition';
 import { CssKeyframesTransition } from './css-keyframes-transition';
 import { KeyframesService } from './keyframes.service';
 import { ViewTransitionDirection, ViewTransitionsService } from './view-transitions.service';
-import { isValidViewTransitionName } from './utils';
+import { fnv1aHash, isValidViewTransitionName } from './utils';
 
 /**
  * Configure view transitions for the element
@@ -16,7 +16,7 @@ export class TransitionNameDirective {
   /**
    * Set the `view-transition-name` property to assign transitions to that element
    */
-  transitionName = input.required<string>();
+  originalTransitionName = input.required<string>({ alias: 'transitionName' });
   /**
    * Configure the animation when the element enters the view
    */
@@ -25,34 +25,67 @@ export class TransitionNameDirective {
    * Configure the animation when the element leaves the view
    */
   outAnimation = input<KeyframesTransition | CssKeyframesTransition>();
+  /**
+   * Whether to keep the original transition name or apply hashing for CSS safety.
+   * Defaults to `false`. Set to `true` to use the name as provided without hashing.
+   */
+  preserveName = input<boolean>(false);
+  /**
+   * Whether to show the `data-original-view-transition-name` containing the provided transition name. Useful for debugging when hashing is enabled. Defaults to `false`.
+   */
+  showOriginalNameAttr = input<boolean>(false);
 
   private readonly _el = inject(ElementRef);
   private readonly _renderer = inject(Renderer2);
   private readonly _keyframesService = inject(KeyframesService);
   private readonly _viewTransitionsService = inject(ViewTransitionsService);
 
+  private readonly _transitionName = computed(() => {
+    const originalTransitionName = this.originalTransitionName();
+
+    return this.preserveName() ? originalTransitionName : `vtn-${fnv1aHash(originalTransitionName)}`;
+  });
+
   constructor() {
     //transitionName
     effect(() => {
-      const transitionName = this.transitionName();
+      this._renderer.setStyle(this._el.nativeElement, 'view-transition-name', this._transitionName());
+    });
 
-      this._renderer.setStyle(this._el.nativeElement, 'view-transition-name', transitionName);
-
+    //originalNameAttr
+    effect(() => {
       queueMicrotask(() => {
-        if (!isValidViewTransitionName(transitionName))
-          console.warn(
-            `The transition name "${transitionName}" is potentially invalid. Please use a valid CSS <custom-ident> value and avoid forbidden values like "unset", "initial", "inherit" and "none".`
+        if (this.showOriginalNameAttr()) {
+          this._renderer.setAttribute(
+            this._el.nativeElement,
+            'data-original-view-transition-name',
+            untracked(this.originalTransitionName)
           );
+        }
       });
     });
 
+    //warn if invalid transition name
+    effect(() => {
+      queueMicrotask(() => {
+        if (!this.preserveName()) return;
+
+        const transitionName = this._transitionName();
+
+        if (isValidViewTransitionName(transitionName)) return;
+
+        console.warn(
+          `The provided transition name "${transitionName}" is potentially invalid. Please use a valid CSS <custom-ident> value and avoid forbidden values like "unset", "initial", "inherit" and "none". Or use hashing by setting "preserveName" to false.`
+        );
+      });
+    });
     //inAnimation
     effect(async () => {
       const animation = this.inAnimation();
 
       if (!animation) return;
 
-      this.setTransition(this.transitionName(), animation, 'in');
+      this.setTransition(this._transitionName(), animation, 'in');
     });
 
     //outAnimation
@@ -61,7 +94,7 @@ export class TransitionNameDirective {
 
       if (!animation) return;
 
-      this.setTransition(this.transitionName(), animation, 'out');
+      this.setTransition(this._transitionName(), animation, 'out');
     });
   }
 

--- a/ngx-easy-view-transitions/src/lib/utils.ts
+++ b/ngx-easy-view-transitions/src/lib/utils.ts
@@ -1,12 +1,11 @@
 /**@internal*/
-export function hashCode(str: string): number {
-  let hash = 0;
-  for (let i = 0, len = str.length; i < len; i++) {
-    const code = str.charCodeAt(i);
-    hash = (hash << 5) - hash + code;
-    hash |= 0; // Convert to 32bit integer
+export function fnv1aHash(str: string) {
+  let hash = 2166136261;
+  for (let i = 0; i < str.length; i++) {
+    hash ^= str.charCodeAt(i);
+    hash = Math.imul(hash, 16777619);
   }
-  return hash;
+  return hash >>> 0;
 }
 
 /**@internal*/


### PR DESCRIPTION
closes #6 

- add hashing to `transitionName`
- add `preserveName `input
- add `showOriginalNameAttr `input
- use fnv1a hashing